### PR TITLE
Users can no longer hackban themselves

### DIFF
--- a/src/commands/hackban.js
+++ b/src/commands/hackban.js
@@ -12,6 +12,10 @@ exports.run = async (client, message, args) => {
     return message.channel.send("<:error:466995152976871434> Invalid ID")
   }
 
+  if(message.author.id == args[0]) {
+    return message.channel.send("<:error:466995152976871434> Don't try and ban yourself.")
+  }
+
   if(message.guild.member(args[0])) {
     if(!message.guild.member(args[0]).bannable) {
       return message.channel.send("<:error:466995152976871434> User is not bannable.")

--- a/src/modules/music.js
+++ b/src/modules/music.js
@@ -225,7 +225,7 @@ exports.play = async function (client, message, query, playNext, ignoreQueue) {
       })
     }
   } else {
-    return message.channel.channelsend('failed to find the video!')
+    return message.channel.send('failed to find the video!')
   }
 }
 


### PR DESCRIPTION
Why was this even possible in the first place

Also fixed something in the music file, which had `message.channel.channelsend()` instead of `message.channel.send()`