### PR TITLE
Bind to SIGINT so Ctrl+C properly shuts down the bot

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,4 +97,10 @@ const init = async () => {
   };
 };
 
+process.on('SIGINT', function(){
+  client.logger.info("Disconnecting...")
+  client.destroy();
+  process.exit();
+});
+
 init();


### PR DESCRIPTION
Adds a bind to SIGINT so that the bot will shut down and properly appear offline on Discord after a Ctrl+C interrupts the process